### PR TITLE
Add CI for benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,45 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  benchmark:
+    name: Benchmark Performance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run benchmarks
+        run: cargo bench --bench basic -- --output-format bencher > bench_current.txt
+
+      - name: Check benchmark regression
+        run: |
+          if [ -f bench_baseline.txt ]; then
+            echo "Comparing benchmarks against baseline"
+            python3 scripts/compare_bench.py bench_baseline.txt bench_current.txt
+          else
+            echo "No baseline benchmark found. Skipping regression check."
+          fi
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: bench_current.txt

--- a/scripts/compare_bench.py
+++ b/scripts/compare_bench.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+LINE_RE = re.compile(
+    r"^test\s+(?P<name>\S+)\s+\.\.\.\s+bench:\s+(?P<value>[0-9.]+)\s+ns/iter(?:.*)$"
+)
+
+def parse_results(path: Path) -> dict[str, float]:
+    results: dict[str, float] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        match = LINE_RE.match(line)
+        if not match:
+            continue
+        results[match.group("name")] = float(match.group("value"))
+    if not results:
+        raise SystemExit(f"No benchmark results parsed from {path}")
+    return results
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: compare_bench.py <baseline> <current>")
+
+    baseline_path = Path(sys.argv[1])
+    current_path = Path(sys.argv[2])
+
+    baseline = parse_results(baseline_path)
+    current = parse_results(current_path)
+
+    regressions: list[tuple[str, float]] = []
+    for name, base_val in baseline.items():
+        if name not in current:
+            continue
+        cur_val = current[name]
+        change = (cur_val - base_val) / base_val * 100.0
+        print(
+            f"{name}: baseline={base_val:.2f}ns current={cur_val:.2f}ns change={change:.2f}%"
+        )
+        if change > 5.0:
+            regressions.append((name, change))
+
+    if regressions:
+        details = ", ".join(f"{name} ({chg:.2f}%)" for name, chg in regressions)
+        raise SystemExit(f"Benchmark regressions detected: {details}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is useful to detect benchmarks performance degradation

Introduced a benchmark workflow (.github/workflows/benchmarks.yml) that runs Criterion benches on every push/PR, uploads the results, and—when a bench_baseline.txt is present—compares the numbers using the new scripts/compare_bench.py script. The parser handles real cargo bench --output-format bencher output and fails the workflow if any benchmark is ≥5% slower; otherwise it prints the delta.

